### PR TITLE
fix(build): generate .d.ts via TS inference to unblock release

### DIFF
--- a/packages/code-core/bunup.config.ts
+++ b/packages/code-core/bunup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "bunup";
+
+export default defineConfig({
+	dts: {
+		inferTypes: true,
+	},
+});

--- a/packages/code-core/src/index.ts
+++ b/packages/code-core/src/index.ts
@@ -110,7 +110,7 @@ export {
 	calculateModelMessagesTokens,
 	clearMessageTokenCache,
 } from "./ai/model-message-token-calculator.js";
-export type { ProviderConfig } from "./ai/providers/base-provider.js";
+export type { ConfigField, ProviderConfig } from "./ai/providers/base-provider.js";
 // ============================================================================
 // Session Management
 // ============================================================================

--- a/packages/code-server/bunup.config.ts
+++ b/packages/code-server/bunup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "bunup";
+
+export default defineConfig({
+	dts: {
+		inferTypes: true,
+	},
+});


### PR DESCRIPTION
## Problem

The `Release` workflow's **Build Packages** step (`bun run build`) fails under CI. bunup generates `.d.ts` files using **isolated declarations** by default, which requires an explicit type annotation on every exported binding. Locally these surface as non-fatal `WARN`s (the build still exits 0 but emits **broken** declarations, e.g. `declare const PROVIDER_REGISTRY: {}` making `ProviderId = never`); under `CI=true` (GitHub Actions) bunup promotes them to **hard errors** and the build fails:

```
ai/providers/index.ts (20:13): TS9013 Expression type cannot be inferred...
```

There are **~220** such errors across `code-core` and `code-server`.

## Why not hand-annotate every export?

The bulk of the offending exports cannot be cleanly hand-annotated:

- **drizzle `sqliteTable(...)` schemas** (`code-core/src/database/schema.ts`) — return deeply-generic `SQLiteTableWithColumns<...>` types.
- **Lens fluent-builder queries/mutations + the router** (`code-server/src/lens/*`) — `query().args(...).returns(...).resolve(...)` and `router(...)` produce large inferred generic types.

Writing those by hand would mean duplicating compiler-inferred types — massive, brittle, and an SSOT violation (and intractable for the router's client-inference type).

## Fix

1. **`dts.inferTypes` for `code-core` and `code-server`** (new `bunup.config.ts` in each). bunup then generates declarations with the **real TypeScript compiler** and full inference — no suppression, no `any`, no `@ts-ignore`. Declarations are now complete and correct (drizzle tables get their real types; the Lens router gets a real `RouterDef<...>` for client inference). `typescript` is already a devDependency in both packages, so no new deps.
2. **Export `ConfigField` from `code-core`'s public surface.** Its public `AIProvider.getConfigSchema()` returns `ConfigField[]`; consumers (code-server lens ops) need the type to be nameable, otherwise the compiler raises `TS4023 "...cannot be named"`.

## Verification

- `CI=true bun run build` -> **6/6 tasks successful, 0 errors**.
- `bun run type-check` improves from **14 pre-existing errors to 10**; the remaining 10 are pre-existing `@sylphx/code-client` issues (`@sylphx/lens-client` missing a `Transport` export) and are unrelated to this change / not in the release path.

Out of scope per instructions: `.github/workflows/release.yml` and `.changeset/` are untouched.