### PR TITLE
Forward-fix workspace protocol package metadata

### DIFF
--- a/.changeset/fair-badgers-publish.md
+++ b/.changeset/fair-badgers-publish.md
@@ -1,0 +1,10 @@
+---
+"@sylphx/code": patch
+"@sylphx/code-api": patch
+"@sylphx/code-client": patch
+"@sylphx/code-core": patch
+"@sylphx/code-server": patch
+"@sylphx/code-web": patch
+---
+
+Forward-fix published package metadata so workspace protocol dependencies are materialized during npm publication.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,5 +10,6 @@ jobs:
       actions: write
       contents: write
       pull-requests: write
+      id-token: write
     uses: SylphxAI/.github/.github/workflows/release.yml@main
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"build:code": "bun --cwd packages/code build",
 		"changeset": "changeset",
 		"changeset:version": "changeset version",
-		"changeset:publish": "changeset publish"
+		"changeset:publish": "echo \"Direct changeset publish is unsafe for Bun workspaces; use the Sylphx release workflow.\" && exit 1"
 	},
 	"engines": {
 		"node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- add a patch changeset for the code package family so a safe release can replace broken npm metadata from 1.0.0
- add `id-token: write` to the release workflow caller
- make the repo-local `changeset:publish` shortcut fail closed instead of running unsafe Bun workspace publication

## Validation
- `git diff --check`
- `jq empty package.json`
- `yq '.' .github/workflows/release.yml`
- npm readback confirmed `@sylphx/code`, `@sylphx/code-client`, and `@sylphx/code-server` latest versions contain `workspace:*` metadata

> Merge order: merge SylphxAI/.github#23 first so the shared `sylphx-changesets-publish` command exists on `main` before this repository can publish.
